### PR TITLE
Correct heading type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Laravel GCM (Google Cloud Messaging) Notification Channel
+# Laravel GCM (Google Cloud Messaging) Notification Channel
 
 Here's the latest documentation on Laravel 5.3 Notifications System: 
 


### PR DESCRIPTION
All other repos have a `h1` for their title which keeps the layout on http://laravel-notification-channels.com consistent
