### PR TITLE
Added the ability to send GCM messages to iOS

### DIFF
--- a/src/GcmChannel.php
+++ b/src/GcmChannel.php
@@ -8,7 +8,6 @@ use Illuminate\Notifications\Events\NotificationFailed;
 use Illuminate\Notifications\Notification;
 use NotificationChannels\Gcm\Exceptions\SendingFailed;
 use ZendService\Google\Gcm\Client;
-use ZendService\Google\Gcm\Message as Packet;
 
 class GcmChannel
 {
@@ -75,6 +74,10 @@ class GcmChannel
         $packet->setRegistrationIds($tokens);
         $packet->setCollapseKey(str_slug($message->title));
         $packet->setData([
+                'title' => $message->title,
+                'message' => $message->message,
+            ] + $message->data);
+        $packet->setNotification([
                 'title' => $message->title,
                 'message' => $message->message,
             ] + $message->data);

--- a/src/GcmChannel.php
+++ b/src/GcmChannel.php
@@ -79,7 +79,7 @@ class GcmChannel
             ] + $message->data);
         $packet->setNotification([
                 'title' => $message->title,
-                'message' => $message->message,
+                'body' => $message->message,
             ] + $message->data);
 
         return $packet;

--- a/src/Packet.php
+++ b/src/Packet.php
@@ -13,7 +13,7 @@ class Packet extends Message
     protected $notification;
 
     /**
-     * Set the notification
+     * Set the notification.
      *
      * @param array $ids
      * @return Message
@@ -33,7 +33,7 @@ class Packet extends Message
      */
     public function toJson()
     {
-        $json = array();
+        $json = [];
         if ($this->registrationIds) {
             $json['registration_ids'] = $this->registrationIds;
         }

--- a/src/Packet.php
+++ b/src/Packet.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace NotificationChannels\Gcm;
+
+use ZendService\Google\Gcm\Message;
+use Zend\Json\Json;
+
+class Packet extends Message
+{
+    /**
+     * @var array
+     */
+    protected $notification;
+
+    /**
+     * Set the notification
+     *
+     * @param array $ids
+     * @return Message
+     */
+    public function setNotification($notification)
+    {
+        $this->notification = $notification;
+        return $this;
+    }
+
+    /**
+     * To JSON
+     * Utility method to put the JSON into the
+     * GCM proper format for sending the message.
+     *
+     * @return string
+     */
+    public function toJson()
+    {
+        $json = array();
+        if ($this->registrationIds) {
+            $json['registration_ids'] = $this->registrationIds;
+        }
+        if ($this->collapseKey) {
+            $json['collapse_key'] = $this->collapseKey;
+        }
+        if ($this->data) {
+            $json['data'] = $this->data;
+        }
+        if ($this->notification) {
+            $json['notification'] = $this->notification;
+        }
+        if ($this->delayWhileIdle) {
+            $json['delay_while_idle'] = $this->delayWhileIdle;
+        }
+        if ($this->timeToLive != 2419200) {
+            $json['time_to_live'] = $this->timeToLive;
+        }
+        if ($this->restrictedPackageName) {
+            $json['restricted_package_name'] = $this->restrictedPackageName;
+        }
+        if ($this->dryRun) {
+            $json['dry_run'] = $this->dryRun;
+        }
+
+        return Json::encode($json);
+    }
+}

--- a/src/Packet.php
+++ b/src/Packet.php
@@ -21,6 +21,7 @@ class Packet extends Message
     public function setNotification($notification)
     {
         $this->notification = $notification;
+
         return $this;
     }
 

--- a/tests/PacketTest.php
+++ b/tests/PacketTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Fruitcake\NotificationChannels\Gcm\Test;
+
+use NotificationChannels\Gcm\Packet;
+
+class PacketTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+    }
+
+    /** @test */
+    public function it_can_render_the_json_for_ios_and_android()
+    {
+        $packet = new Packet();
+
+        $packet->setRegistrationIds(['my-token']);
+        $packet->setCollapseKey('my-title');
+        $packet->setData([
+            'title' => 'My Notification',
+            'message' => 'My message',
+        ]);
+        $packet->setNotification([
+            'title' => 'My Notification',
+            'body' => 'My message',
+        ]);
+
+        $this->assertEquals($packet->toJson(), '{"registration_ids":["my-token"],"collapse_key":"my-title","data":{"title":"My Notification","message":"My message"},"notification":{"title":"My Notification","body":"My message"}}');
+    }
+}


### PR DESCRIPTION
GCM can send push messages to iOS devices too. For that, a new 'notification' key is needed.

Since `ZendService\Google\Gcm\Message` doesn't provice this key, I extended the class, added the property and rewrite the `toJson` method.

Also change the Packet that `GcmChannel` creates.