### PR TITLE
Adding sound option to message based on GCM docs

### DIFF
--- a/src/GcmChannel.php
+++ b/src/GcmChannel.php
@@ -80,7 +80,7 @@ class GcmChannel
         $packet->setNotification([
                 'title' => $message->title,
                 'body' => $message->message,
-				'sound' => $message->sound,
+                'sound' => $message->sound,
             ] + $message->data);
 
         return $packet;

--- a/src/GcmChannel.php
+++ b/src/GcmChannel.php
@@ -80,6 +80,7 @@ class GcmChannel
         $packet->setNotification([
                 'title' => $message->title,
                 'body' => $message->message,
+				'sound' => $message->sound,
             ] + $message->data);
 
         return $packet;

--- a/src/GcmChannel.php
+++ b/src/GcmChannel.php
@@ -101,7 +101,7 @@ class GcmChannel
             }
 
             $this->events->fire(
-                new NotificationFailed($notifiable, $notification, $this, [
+                new NotificationFailed($notifiable, $notification, get_class($this), [
                     'token' => $token,
                     'error' => $result['error'],
                 ])

--- a/src/GcmMessage.php
+++ b/src/GcmMessage.php
@@ -7,6 +7,8 @@ class GcmMessage
     const PRIORITY_NORMAL = 'normal';
     const PRIORITY_HIGH = 'high';
 
+    const DEFAULT_SOUND = 'default';
+
     /**
      * The title of the notification.
      *
@@ -36,6 +38,13 @@ class GcmMessage
      */
     public $priority = self::PRIORITY_NORMAL;
 
+	/**
+	 * Notification sound
+	 *
+	 * @var string
+	 */
+	public $sound = self::DEFAULT_SOUND;
+
     /**
      * Additional data of the notification.
      *
@@ -51,9 +60,9 @@ class GcmMessage
      *
      * @return static
      */
-    public static function create($title = null, $message = null, $data = [], $priority = self::PRIORITY_NORMAL)
+    public static function create($title = null, $message = null, $data = [], $priority = self::PRIORITY_NORMAL, $sound = self::DEFAULT_SOUND)
     {
-        return new static($title, $message, $data, $priority);
+        return new static($title, $message, $data, $priority, $sound);
     }
 
     /**
@@ -61,13 +70,15 @@ class GcmMessage
      * @param string|null $message
      * @param array $data
      * @param string $priority
+	 * @param string $sound
      */
-    public function __construct($title = null, $message = null, $data = [], $priority = self::PRIORITY_NORMAL)
+    public function __construct($title = null, $message = null, $data = [], $priority = self::PRIORITY_NORMAL, $sound = self::DEFAULT_SOUND)
     {
         $this->title = $title;
         $this->message = $message;
         $this->data = $data;
         $this->priority = $priority;
+        $this->sound = $sound;
     }
 
     /**
@@ -125,6 +136,20 @@ class GcmMessage
 
         return $this;
     }
+
+	/**
+	 * Set the sound for notification
+	 *
+	 * @param string $sound
+	 *
+	 * @return $this
+	 */
+	public function sound($sound)
+	{
+		$this->sound = $sound;
+
+		return $this;
+	}
 
     /**
      * Add data to the notification.

--- a/src/GcmMessage.php
+++ b/src/GcmMessage.php
@@ -38,12 +38,12 @@ class GcmMessage
      */
     public $priority = self::PRIORITY_NORMAL;
 
-	/**
-	 * Notification sound
-	 *
-	 * @var string
-	 */
-	public $sound = self::DEFAULT_SOUND;
+    /**
+     * Notification sound
+     *
+     * @var string
+     */
+    public $sound = self::DEFAULT_SOUND;
 
     /**
      * Additional data of the notification.
@@ -70,7 +70,7 @@ class GcmMessage
      * @param string|null $message
      * @param array $data
      * @param string $priority
-	 * @param string $sound
+     * @param string $sound
      */
     public function __construct($title = null, $message = null, $data = [], $priority = self::PRIORITY_NORMAL, $sound = self::DEFAULT_SOUND)
     {
@@ -137,19 +137,19 @@ class GcmMessage
         return $this;
     }
 
-	/**
-	 * Set the sound for notification
-	 *
-	 * @param string $sound
-	 *
-	 * @return $this
-	 */
-	public function sound($sound)
-	{
-		$this->sound = $sound;
+    /**
+     * Set the sound for notification
+     *
+     * @param string $sound
+     *
+     * @return $this
+     */
+    public function sound($sound)
+    {
+        $this->sound = $sound;
 
-		return $this;
-	}
+        return $this;
+    }
 
     /**
      * Add data to the notification.

--- a/tests/GcmMessageTest.php
+++ b/tests/GcmMessageTest.php
@@ -72,16 +72,16 @@ class GcmMessageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(GcmMessage::PRIORITY_HIGH, $this->message->priority);
     }
 
-	/** @test */
-	public function it_has_default_sound()
-	{
-		$this->assertEquals(GcmMessage::DEFAULT_SOUND, $this->message->sound);
-	}
+    /** @test */
+    public function it_has_default_sound()
+    {
+        $this->assertEquals(GcmMessage::DEFAULT_SOUND, $this->message->sound);
+    }
 
-	/** @test */
-	public function it_can_set_the_sound()
-	{
-		$this->message->sound(GcmMessage::DEFAULT_SOUND);
-		$this->assertEquals(GcmMessage::DEFAULT_SOUND, $this->message->sound);
-	}
+    /** @test */
+    public function it_can_set_the_sound()
+    {
+        $this->message->sound(GcmMessage::DEFAULT_SOUND);
+        $this->assertEquals(GcmMessage::DEFAULT_SOUND, $this->message->sound);
+    }
 }

--- a/tests/GcmMessageTest.php
+++ b/tests/GcmMessageTest.php
@@ -19,21 +19,23 @@ class GcmMessageTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function it_can_accept_parameters_when_constructing_a_message()
     {
-        $message = new GcmMessage('myTitle', 'myMessage', ['foo' => 'bar'], GcmMessage::PRIORITY_HIGH);
+        $message = new GcmMessage('myTitle', 'myMessage', ['foo' => 'bar'], GcmMessage::PRIORITY_HIGH, GcmMessage::DEFAULT_SOUND);
         $this->assertEquals('myTitle', $message->title);
         $this->assertEquals('myMessage', $message->message);
         $this->assertEquals('bar', $message->data['foo']);
         $this->assertEquals(GcmMessage::PRIORITY_HIGH, $message->priority);
+		$this->assertEquals(GcmMessage::DEFAULT_SOUND, $message->sound);
     }
 
     /** @test */
     public function it_provides_a_create_method()
     {
-        $message = GcmMessage::create('myTitle', 'myMessage', ['foo' => 'bar'], GcmMessage::PRIORITY_HIGH);
+        $message = GcmMessage::create('myTitle', 'myMessage', ['foo' => 'bar'], GcmMessage::PRIORITY_HIGH, GcmMessage::DEFAULT_SOUND);
         $this->assertEquals('myTitle', $message->title);
         $this->assertEquals('myMessage', $message->message);
         $this->assertEquals('bar', $message->data['foo']);
         $this->assertEquals(GcmMessage::PRIORITY_HIGH, $message->priority);
+		$this->assertEquals(GcmMessage::DEFAULT_SOUND, $message->sound);
     }
 
     /** @test */
@@ -69,4 +71,17 @@ class GcmMessageTest extends \PHPUnit_Framework_TestCase
         $this->message->priority(GcmMessage::PRIORITY_HIGH);
         $this->assertEquals(GcmMessage::PRIORITY_HIGH, $this->message->priority);
     }
+
+	/** @test */
+	public function it_has_default_sound()
+	{
+		$this->assertEquals(GcmMessage::DEFAULT_SOUND, $this->message->sound);
+	}
+
+	/** @test */
+	public function it_can_set_the_sound()
+	{
+		$this->message->priority(GcmMessage::DEFAULT_SOUND);
+		$this->assertEquals(GcmMessage::DEFAULT_SOUND, $this->message->sound);
+	}
 }

--- a/tests/GcmMessageTest.php
+++ b/tests/GcmMessageTest.php
@@ -81,7 +81,7 @@ class GcmMessageTest extends \PHPUnit_Framework_TestCase
 	/** @test */
 	public function it_can_set_the_sound()
 	{
-		$this->message->priority(GcmMessage::DEFAULT_SOUND);
+		$this->message->sound(GcmMessage::DEFAULT_SOUND);
 		$this->assertEquals(GcmMessage::DEFAULT_SOUND, $this->message->sound);
 	}
 }


### PR DESCRIPTION
Based on this docs https://developers.google.com/cloud-messaging/http-server-ref 
sound is added to notification payload.