### PR TITLE
Dependency updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 env:
   matrix:

--- a/composer.json
+++ b/composer.json
@@ -11,16 +11,16 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
-        "illuminate/events": "^5.1|^5.2|^5.3",
-        "illuminate/notifications": "^5.3",
-        "illuminate/queue": "^5.1|^5.2|^5.3",
-        "illuminate/support": "^5.1|^5.2|^5.3",
+        "php": ">=7.0.0",
+        "illuminate/events": "^5.5",
+        "illuminate/notifications": "^5.5",
+        "illuminate/queue": "^5.5",
+        "illuminate/support": "^5.5",
         "zendframework/zendservice-google-gcm": "^2.0"
     },
     "require-dev": {
-        "mockery/mockery": "^0.9.5",
-        "phpunit/phpunit": "4.*"
+        "mockery/mockery": "~1.0",
+        "phpunit/phpunit": "~6.0"
     },
     "autoload": {
         "psr-4": {
@@ -29,7 +29,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "NotificationChannels\\Gcm\\Test\\": "tests"
+            "NotificationChannels\\Gcm\\Tests\\": "tests"
         }
     },
     "scripts": {

--- a/src/GcmChannel.php
+++ b/src/GcmChannel.php
@@ -4,10 +4,10 @@ namespace NotificationChannels\Gcm;
 
 use Exception;
 use Illuminate\Events\Dispatcher;
-use Illuminate\Notifications\Events\NotificationFailed;
+use ZendService\Google\Gcm\Client;
 use Illuminate\Notifications\Notification;
 use NotificationChannels\Gcm\Exceptions\SendingFailed;
-use ZendService\Google\Gcm\Client;
+use Illuminate\Notifications\Events\NotificationFailed;
 
 class GcmChannel
 {

--- a/src/GcmMessage.php
+++ b/src/GcmMessage.php
@@ -39,7 +39,7 @@ class GcmMessage
     public $priority = self::PRIORITY_NORMAL;
 
     /**
-     * Notification sound
+     * Notification sound.
      *
      * @var string
      */
@@ -138,7 +138,7 @@ class GcmMessage
     }
 
     /**
-     * Set the sound for notification
+     * Set the sound for notification.
      *
      * @param string $sound
      *

--- a/src/GcmServiceProvider.php
+++ b/src/GcmServiceProvider.php
@@ -2,9 +2,9 @@
 
 namespace NotificationChannels\Gcm;
 
-use Illuminate\Support\ServiceProvider;
 use Zend\Http\Client\Adapter\Curl;
 use ZendService\Google\Gcm\Client;
+use Illuminate\Support\ServiceProvider;
 
 class GcmServiceProvider extends ServiceProvider
 {

--- a/src/Packet.php
+++ b/src/Packet.php
@@ -36,7 +36,7 @@ class Packet extends Message
     {
         $json = [];
 
-        if ( ! empty($this->registrationIds)) {
+        if (! empty($this->registrationIds)) {
             $json['registration_ids'] = $this->registrationIds;
         }
 
@@ -44,23 +44,26 @@ class Packet extends Message
             $json['collapse_key'] = $this->collapseKey;
         }
 
-        if ( ! empty($this->data)) {
+        if (! empty($this->data)) {
             $json['data'] = $this->data;
         }
 
-        if ( ! empty($this->notification)) {
+        if (! empty($this->notification)) {
             $json['notification'] = $this->notification;
         }
 
         if ($this->delayWhileIdle) {
             $json['delay_while_idle'] = $this->delayWhileIdle;
         }
+
         if ($this->timeToLive != 2419200) {
             $json['time_to_live'] = $this->timeToLive;
         }
+
         if ($this->restrictedPackageName) {
             $json['restricted_package_name'] = $this->restrictedPackageName;
         }
+
         if ($this->dryRun) {
             $json['dry_run'] = $this->dryRun;
         }

--- a/tests/GcmChannelTest.php
+++ b/tests/GcmChannelTest.php
@@ -1,17 +1,16 @@
 <?php
 
-namespace NotificationChannels\Gcm\Test;
+namespace NotificationChannels\Gcm\Tests;
 
+use Mockery;
 use Illuminate\Events\Dispatcher;
+use ZendService\Google\Gcm\Client;
 use Illuminate\Notifications\Notifiable;
 use NotificationChannels\Gcm\GcmChannel;
-use Illuminate\Notifications\Notification;
 use NotificationChannels\Gcm\GcmMessage;
-use PHPUnit_Framework_TestCase;
-use Mockery;
-use ZendService\Google\Gcm\Client;
+use Illuminate\Notifications\Notification;
 
-class ChannelTest extends PHPUnit_Framework_TestCase
+class ChannelTest extends TestCase
 {
     /**
      * @var Client
@@ -33,12 +32,6 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $this->channel = new GcmChannel($this->client, $this->events);
         $this->notification = new TestNotification;
         $this->notifiable = new TestNotifiable;
-    }
-
-    public function tearDown()
-    {
-        Mockery::close();
-        parent::tearDown();
     }
 
     /** @test */

--- a/tests/GcmMessageTest.php
+++ b/tests/GcmMessageTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Fruitcake\NotificationChannels\Gcm\Test;
+namespace NotificationChannels\Gcm\Tests;
 
 use NotificationChannels\Gcm\GcmMessage;
 
-class GcmMessageTest extends \PHPUnit_Framework_TestCase
+class GcmMessageTest extends TestCase
 {
     /** @var GcmMessage */
     protected $message;

--- a/tests/GcmMessageTest.php
+++ b/tests/GcmMessageTest.php
@@ -24,7 +24,7 @@ class GcmMessageTest extends TestCase
         $this->assertEquals('myMessage', $message->message);
         $this->assertEquals('bar', $message->data['foo']);
         $this->assertEquals(GcmMessage::PRIORITY_HIGH, $message->priority);
-		$this->assertEquals(GcmMessage::DEFAULT_SOUND, $message->sound);
+        $this->assertEquals(GcmMessage::DEFAULT_SOUND, $message->sound);
     }
 
     /** @test */
@@ -35,7 +35,7 @@ class GcmMessageTest extends TestCase
         $this->assertEquals('myMessage', $message->message);
         $this->assertEquals('bar', $message->data['foo']);
         $this->assertEquals(GcmMessage::PRIORITY_HIGH, $message->priority);
-		$this->assertEquals(GcmMessage::DEFAULT_SOUND, $message->sound);
+        $this->assertEquals(GcmMessage::DEFAULT_SOUND, $message->sound);
     }
 
     /** @test */

--- a/tests/Notifiable.php
+++ b/tests/Notifiable.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace NotificationChannels\Gcm\Test;
+namespace NotificationChannels\Gcm\Tests;
 
 class Notifiable
 {

--- a/tests/PacketTest.php
+++ b/tests/PacketTest.php
@@ -1,16 +1,11 @@
 <?php
 
-namespace Fruitcake\NotificationChannels\Gcm\Test;
+namespace NotificationChannels\Gcm\Tests;
 
 use NotificationChannels\Gcm\Packet;
 
-class PacketTest extends \PHPUnit_Framework_TestCase
+class PacketTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-    }
-
     /** @test */
     public function it_can_render_the_json_for_ios_and_android()
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace NotificationChannels\Gcm\Tests;
+
+use Mockery;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        if ($container = Mockery::getContainer()) {
+            $this->addToAssertionCount($container->mockery_getExpectationCount());
+        }
+
+        Mockery::close();
+    }
+}


### PR DESCRIPTION
This updates a bunch of our old dependencies, and makes some additional changes.

* Updates the PHP dependency to PHP 7.0.0+
* Updates the minimum Laravel constraint to 5.5
* Updates the namespace of the test suite to match path
* Creates a new abstract TestCase to unify Mockery teardown