### PR TITLE
Allow notification routing to depend on notification being sent

### DIFF
--- a/src/GcmChannel.php
+++ b/src/GcmChannel.php
@@ -38,7 +38,7 @@ class GcmChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        $tokens = (array) $notifiable->routeNotificationFor('gcm');
+        $tokens = (array) $notifiable->routeNotificationFor('gcm', $notification);
         if (empty($tokens)) {
             return;
         }


### PR DESCRIPTION
This adds support for the feature added in Laravel 5.6 for routing based on the notification being sent.
[The merged PR is here](https://github.com/laravel/framework/pull/22289)