### PR TITLE
Changed fire method to dispatch to support Laravel 5.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/laravel-notification-channels/gcm/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/gcm/?branch=master)
 [![Total Downloads](https://img.shields.io/packagist/dt/laravel-notification-channels/gcm.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/gcm)
 
-This package makes it easy to send notifications using Google Cloud Messaging (GCM) with Laravel 5.3.
+This package makes it easy to send notifications using Google Cloud Messaging (GCM) with Laravel 5.8.
 
 This package is based on [ZendService\Google\Gcm](https://framework.zend.com/manual/2.4/en/modules/zendservice.google.gcm.html), so please read that documentation for more information.
 

--- a/src/GcmChannel.php
+++ b/src/GcmChannel.php
@@ -110,7 +110,7 @@ class GcmChannel
                 continue;
             }
 
-            $this->events->fire(
+            $this->events->dispatch(
                 new NotificationFailed($notifiable, $notification, get_class($this), [
                     'token' => $token,
                     'error' => $result['error'],

--- a/tests/GcmChannelTest.php
+++ b/tests/GcmChannelTest.php
@@ -25,7 +25,7 @@ class ChannelTest extends TestCase
     /** @var Notification */
     protected $notification;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->client = Mockery::mock(Client::class);
         $this->events = Mockery::mock(Dispatcher::class);

--- a/tests/GcmMessageTest.php
+++ b/tests/GcmMessageTest.php
@@ -9,7 +9,7 @@ class GcmMessageTest extends TestCase
     /** @var GcmMessage */
     protected $message;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 


### PR DESCRIPTION
This package doesn't currently work in Laravel 5.8 due to the removal of the `fire` method on the `Illuminate\Events\Dispatcher` class. The solution is to replace the `fire` method with `dispatch`.

Reference: [Laravel 5.8 Upgrade Guide](https://laravel.com/docs/5.8/upgrade)